### PR TITLE
[TASK] Add phpstan ignore rule for QueryBuilder->where type

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,11 @@ parameters:
   excludes_analyse:
     - %currentWorkingDirectory%/../Classes/Hooks/DataHandlerHook.php
     - %currentWorkingDirectory%/../Classes/Mail/GenerateCheckResultPlainMail.php
+
+  ignoreErrors:
+    # https://phpstan.org/user-guide/ignoring-errors
+    # must use regular expressions here!!!
+
+    # temporary, remove after TYPO3 v10.4.24 / 11.5.6
+    # see issue https://github.com/sypets/brofix/issues/150
+    - '# Parameter \#1 \.\.\.\$where of method TYPO3\\CMS\\Core\\Database\\Query\\QueryBuilder::andWhere\(\) expects array<int,string>|Doctrine\\DBAL\\Query\\Expression\\CompositeExpression, string given\.#'


### PR DESCRIPTION
Temporary fix for suppressing type warnings. Current core version
has wrong type declaration in phpdoc. This can be removed for
TYPO3 core version 10.4.24 / 11.5.6.

This does not apply to TYPO3 9. If TYPO3 9 is tested as well, the
phpstan.neon files must be separated.